### PR TITLE
Address Issue #2: Properly handle test failures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### v0.1.4 (2017-07-27)
+
+Features:
+
+* Add Jasmine test failure messages to JUnit output
+
 ### v0.1.3 (2015-04-12)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add project dependency. E.g if you use maven:
 <dependency>
   <groupId>de.helwich.junit</groupId>
   <artifactId>junit-jasmine-runner</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>de.helwich.junit</groupId>
   <artifactId>junit-jasmine-runner</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <packaging>jar</packaging>
 
   <name>JUnit Jasmine Runner</name>

--- a/src/main/resources/de/helwich/junit/reporter.js
+++ b/src/main/resources/de/helwich/junit/reporter.js
@@ -26,11 +26,17 @@
         },
         specStarted: function(result) {
             //print("specStarted"+JSON.stringify(result));
-            junitReporter.specStarted(result.id, result.description, result.fullName, result.failedExpectations);
+            // JS stack isn't particularly useful right now because it doesn't show lines in the test file itself.
+            var failureMessages = result.failedExpectations.map(function(failedExpectation) { return failedExpectation.message; });
+            // print("Failure messages: " + failureMessages);
+            junitReporter.specStarted(result.id, result.description, result.fullName, failureMessages);
         },
         specDone: function(result) {
-            //print("specDone"+JSON.stringify(result));
-            junitReporter.specDone(result.id, result.description, result.fullName, result.failedExpectations, result.status);
+            // print("specDone"+JSON.stringify(result));
+            // JS stack isn't particularly useful right now because it doesn't show lines in the test file itself.
+            var failureMessages = result.failedExpectations.map(function(failedExpectation) { return failedExpectation.message; });
+            // print("Failure messages: " + failureMessages);
+            junitReporter.specDone(result.id, result.description, result.fullName, failureMessages, result.status);
         }
     };
 

--- a/src/test/java/js/FailingTest.java
+++ b/src/test/java/js/FailingTest.java
@@ -1,0 +1,9 @@
+package js;
+
+import de.helwich.junit.JasmineTest;
+import de.helwich.junit.JasmineTestRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(JasmineTestRunner.class)
+@JasmineTest(test = { "failing" })
+public class FailingTest {}

--- a/src/test/js/failing.js
+++ b/src/test/js/failing.js
@@ -1,0 +1,9 @@
+/**
+We want to demonstrate the behavior of the test framework when a test fails.
+ */
+describe("A failing suite", function() {
+  // Enable this test to see how the Jasmine test runner handles test failures.
+  xit("contains spec with a failing expectation", function() {
+    expect(true).toBe(false);
+  });
+});


### PR DESCRIPTION
Addresses #2 :
Right now a failing test throws a NullPointerException owing to the null passed to the constructor.
Instead we use the Jasmine test failure messages in the output for failing tests.

This PR also bumps  the version number.